### PR TITLE
update the unused 'doc' variable to be assigned to docs allowing the …

### DIFF
--- a/LLM Generic APP/test.ipynb
+++ b/LLM Generic APP/test.ipynb
@@ -102,7 +102,7 @@
     "def chunk_data(docs,chunk_size=800,chunk_overlap=50):\n",
     "    text_splitter=RecursiveCharacterTextSplitter(chunk_size=chunk_size,chunk_overlap=chunk_overlap)\n",
     "    doc=text_splitter.split_documents(docs)\n",
-    "    return docs"
+    "    return doc"
    ]
   },
   {


### PR DESCRIPTION
In _LLM Generic APP > test.ipynb_ in the method `chunk_data` it is currently returning `docs` and should return `doc`. In its current form, `doc` is an unused variable. 

Currently this function doesn't do anything other than pass through the original `docs` argument .

See below where `doc` is currently being unused:

```python
def chunk_data(docs,chunk_size=800,chunk_overlap=50):
    text_splitter=RecursiveCharacterTextSplitter(chunk_size=chunk_size,chunk_overlap=chunk_overlap)
    doc=text_splitter.split_documents(docs)  # <-- doc unused
    return docs  # <-- returning initial docs argument
```
